### PR TITLE
remove redundant version number in name of binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,8 +26,8 @@ snapshot:
 
 dockers:
 - image_templates:
-  - "docker.io/appuio/image-cleanup:{{ .Tag }}"
-  - "docker.io/appuio/image-cleanup:{{ .Major }}"
+  - "docker.io/appuio/image-cleanup:v{{ .Tag }}"
+  - "docker.io/appuio/image-cleanup:v{{ .Major }}"
 
 changelog:
   sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ snapshot:
 
 dockers:
 - image_templates:
-  - "docker.io/appuio/image-cleanup:v{{ .Tag }}"
+  - "docker.io/appuio/image-cleanup:v{{ .Version }}"
   - "docker.io/appuio/image-cleanup:v{{ .Major }}"
 
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
 
 archives:
 - format: binary
+  name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 
 checksum:
   name_template: 'checksums.txt'

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ go test ./...
 docker run --rm -it appuio/image-cleanup:<tag>
 ```
 
+## Release
+
+Push a git tag with the scheme `vX.Y.Z`.
+
 ## License
 
 This project is BSD 3-Clause licensed (see LICENSE file for details).


### PR DESCRIPTION
The version number (with prepended v) is in the download path, so maybe we don't also need it here (without the prepended v)...?